### PR TITLE
Add Obsidian editor object as a utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,14 @@ saveAttachment: (name: string, ext: string, data: ArrayBuffer) =>
     Promise<TFile>;
 ```
 
+If you need more information about or control over the editor state, the [Obsidian `editor` object](https://docs.obsidian.md/Plugins/Editor/Editor) is provided as a utility.
+
 `lodash`, `moment.js` and `mime` are also provided as utilities. Check out the following example:
 
 ```javascript
 export async function myTransform(
     input,
-    { turndown, _, moment, mime, saveAttachment }
+    { turndown, editor, _, moment, mime, saveAttachment }
 ) {
     if (input.types.includes("text/html")) {
         const html = await input.getType("text/html");

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,7 @@ async function executePaste(
             const path = await getAvailablePathForAttachments(name, ext, file);
             return vault.createBinary(path, data);
         },
+        editor,
     };
     const internalParams = { shouldHandleImagePasting: !withinEvent };
     try {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import { Editor, TFile } from "obsidian";
 import TurndownService from "turndown";
 export type TransformType = "text" | "blob";
 
@@ -44,6 +44,7 @@ export interface TransformUtils extends TransformUtilsBase {
         ext: string,
         data: ArrayBuffer
     ) => Promise<TFile>;
+    editor: Editor;
 }
 
 export interface AdvpasteInternalParams {


### PR DESCRIPTION
In my case, I wanted my custom transform to be able to see the current line so that I could make the indentation level of the pasted content match the current line's indentation. If the [Obsidian `editor` object](https://docs.obsidian.md/Plugins/Editor/Editor) is exposed, it allows me to do that.